### PR TITLE
Remove dependency on sfsymbols

### DIFF
--- a/example/lib/storybook/stories/help_option_button_story.dart
+++ b/example/lib/storybook/stories/help_option_button_story.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
 import 'package:help_ukraine_widget/help_ukraine_widget.dart';
 
 import 'package:widgetbook/widgetbook.dart';
@@ -36,9 +35,11 @@ WidgetbookComponent get helpOptionButtonStory => WidgetbookComponent(
                 onTap: onTap,
                 title: title,
                 backgroundColor: color,
-                child: const Icon(
-                  SFSymbols.chevron_down,
-                  size: 14,
+                child: const Chevron(
+                  direction: ChevronDirection.up,
+                  size: Size.square(10),
+                  color: Colors.black,
+                  lineWidth: 2,
                 ),
               ),
             );

--- a/example/lib/storybook/stories/help_options_list.dart
+++ b/example/lib/storybook/stories/help_options_list.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
 import 'package:help_ukraine_widget/help_ukraine_widget.dart';
 import 'package:widgetbook/widgetbook.dart';
 
@@ -18,24 +17,15 @@ WidgetbookComponent get helpOptionsListStory => WidgetbookComponent(
                     children: const [
                       HelpOptionButton(
                         title: 'Donate',
-                        child: Icon(
-                          SFSymbols.money_dollar,
-                          size: 19,
-                        ),
+                        child: Text("💸"),
                       ),
                       HelpOptionButton(
                         title: 'Support Ukraine',
-                        child: Icon(
-                          SFSymbols.heart,
-                          size: 19,
-                        ),
+                        child: Text("❤️"),
                       ),
                       HelpOptionButton(
                         title: 'Share this widget',
-                        child: Icon(
-                          SFSymbols.pin,
-                          size: 19,
-                        ),
+                        child: Text("📌"),
                       ),
                     ],
                   ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -132,13 +132,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_sfsymbols:
-    dependency: "direct main"
-    description:
-      name: flutter_sfsymbols
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_sfsymbols: ^2.0.0
   help_ukraine_widget:
     path: ..
   widgetbook: ^2.4.1
@@ -23,8 +22,3 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-
-  fonts:
-    - family: sficonsets
-      fonts:
-        - asset: packages/flutter_sfsymbols/fonts/sficonsets.ttf

--- a/lib/src/components/buttons/details_button.dart
+++ b/lib/src/components/buttons/details_button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:help_ukraine_widget/src/components/chevron_down.dart';
+import 'package:help_ukraine_widget/src/components/components.dart';
 import 'package:help_ukraine_widget/src/theme/font_config.dart';
 
 /// It's a button that changes color when you hover over it
@@ -62,7 +62,8 @@ class DetailsButton extends StatelessWidget {
               child: SizedBox(
                 width: chevronWidth,
                 height: chevronHeight,
-                child: ChevronDown(
+                child: Chevron(
+                  direction: ChevronDirection.down,
                   color: color,
                   size: const Size(chevronWidth, chevronHeight),
                   lineWidth: lineWidth,

--- a/lib/src/components/buttons/rounded_button.dart
+++ b/lib/src/components/buttons/rounded_button.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
-import 'package:help_ukraine_widget/help_ukraine_widget.dart';
+import 'package:help_ukraine_widget/src/components/components.dart';
 
 /// [RoundedButton] is a rounded button with text that states underlined
 /// when onHover active.
@@ -61,10 +60,11 @@ class _RoundedButtonState extends State<RoundedButton> {
                     decoration: _isHovered ? TextDecoration.underline : null,
                   ),
             ),
-            const Icon(
-              SFSymbols.chevron_right,
-              size: _iconSize,
+            const Chevron(
+              size: Size.square(_iconSize / 2),
               color: Colors.blueAccent,
+              lineWidth: 2,
+              direction: ChevronDirection.right,
             ),
           ],
         ),

--- a/lib/src/components/chevron.dart
+++ b/lib/src/components/chevron.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// chevron Icon
-class ChevronDown extends StatelessWidget {
+class Chevron extends StatelessWidget {
   /// size of the canvas to draw a chevron on.
   final Size size;
 
@@ -11,24 +11,56 @@ class ChevronDown extends StatelessWidget {
   /// width of chevron lines.
   final double lineWidth;
 
+  /// Direction where the chevron point will be facing.
+  final ChevronDirection direction;
+
   /// Constructor
-  const ChevronDown({
+  const Chevron({
     Key? key,
     required this.size,
     required this.color,
     required this.lineWidth,
+    required this.direction,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return CustomPaint(
-      size: size,
-      painter: _CrossPainter(
-        color: color,
-        lineWidth: lineWidth,
+    return RotatedBox(
+      quarterTurns: _quartedTurnsForDirection(direction),
+      child: CustomPaint(
+        size: size,
+        painter: _CrossPainter(
+          color: color,
+          lineWidth: lineWidth,
+        ),
       ),
     );
   }
+
+  int _quartedTurnsForDirection(ChevronDirection direction) {
+    return const {
+          ChevronDirection.down: 0,
+          ChevronDirection.left: 1,
+          ChevronDirection.up: 2,
+          ChevronDirection.right: 3,
+        }[direction] ??
+        0;
+  }
+}
+
+/// The direction where the chevron arrow will be pointing.
+enum ChevronDirection {
+  /// Chevron pointing upwards
+  up,
+
+  /// Chevron pointing to the right
+  right,
+
+  /// Chevron pointing downwards
+  down,
+
+  /// Chevron pointing to the left
+  left
 }
 
 class _CrossPainter extends CustomPainter {

--- a/lib/src/components/components.dart
+++ b/lib/src/components/components.dart
@@ -1,5 +1,6 @@
 export 'buttons/buttons.dart';
 export 'card_rounded/card_rounded.dart';
+export 'chevron.dart';
 export 'flag_card.dart';
 export 'flag_widget.dart';
 export 'hover_wrapper.dart';

--- a/lib/src/widgets/help_collection/horizontal_help_widget.dart
+++ b/lib/src/widgets/help_collection/horizontal_help_widget.dart
@@ -43,6 +43,7 @@ class HorizontalHelpWidget extends StatelessWidget {
           child: LinksCardWidget(
             options: defaultOptionsList,
             onClose: _controller.goBack,
+            chevronSize: const Size.square(9),
           ),
         ),
       ),

--- a/lib/src/widgets/help_collection/overlay_flag_help_widget.dart
+++ b/lib/src/widgets/help_collection/overlay_flag_help_widget.dart
@@ -50,6 +50,7 @@ class OverlayFlagHelpWidget extends StatelessWidget {
               LinksCardWidget(
                 options: defaultOptionsList,
                 onClose: _controller.goBack,
+                chevronSize: const Size.square(6.5),
               ),
             ],
           ),

--- a/lib/src/widgets/links_card_widget/links_card_button.dart
+++ b/lib/src/widgets/links_card_widget/links_card_button.dart
@@ -49,10 +49,9 @@ class _LinksCardButtonState extends State<LinksCardButton> {
                   fontSize: fontSize,
                 ),
           ),
-          const SizedBox(width: 5),
           Padding(
             padding: const EdgeInsets.only(
-              left: 2,
+              left: 7,
               bottom: 2.5,
             ),
             child: Chevron(

--- a/lib/src/widgets/links_card_widget/links_card_button.dart
+++ b/lib/src/widgets/links_card_widget/links_card_button.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
 
 import 'package:help_ukraine_widget/help_ukraine_widget.dart';
 
@@ -8,8 +7,15 @@ class LinksCardButton extends StatefulWidget {
   /// onTap for [HoverWrapper]
   final VoidCallback onTap;
 
+  /// The size of the chevron to the right of the text.
+  final Size chevronSize;
+
   /// Constructor
-  const LinksCardButton({Key? key, required this.onTap}) : super(key: key);
+  const LinksCardButton({
+    Key? key,
+    required this.onTap,
+    required this.chevronSize,
+  }) : super(key: key);
 
   @override
   State<LinksCardButton> createState() => _LinksCardButtonState();
@@ -17,8 +23,6 @@ class LinksCardButton extends StatefulWidget {
 
 class _LinksCardButtonState extends State<LinksCardButton> {
   bool _isHovered = false;
-
-  static const _iconSize = 13.0;
 
   void _onHoverChanged(bool value) {
     setState(() {
@@ -46,10 +50,17 @@ class _LinksCardButtonState extends State<LinksCardButton> {
                 ),
           ),
           const SizedBox(width: 5),
-          Icon(
-            SFSymbols.chevron_up,
-            color: color,
-            size: _iconSize,
+          Padding(
+            padding: const EdgeInsets.only(
+              left: 2,
+              bottom: 2.5,
+            ),
+            child: Chevron(
+              direction: ChevronDirection.up,
+              size: widget.chevronSize,
+              color: color,
+              lineWidth: 1.0,
+            ),
           ),
         ],
       ),

--- a/lib/src/widgets/links_card_widget/links_card_widget.dart
+++ b/lib/src/widgets/links_card_widget/links_card_widget.dart
@@ -13,11 +13,15 @@ class LinksCardWidget extends StatelessWidget {
   /// on the 'Hide' button.
   final VoidCallback onClose;
 
+  /// The size of the chevron to the right of the text.
+  final Size chevronSize;
+
   /// Constructor
   const LinksCardWidget({
     Key? key,
     required this.options,
     required this.onClose,
+    required this.chevronSize,
   }) : super(key: key);
 
   @override
@@ -41,7 +45,10 @@ class LinksCardWidget extends StatelessWidget {
             height: 1,
           ),
         ),
-        LinksCardButton(onTap: onClose),
+        LinksCardButton(
+          onTap: onClose,
+          chevronSize: chevronSize,
+        ),
       ],
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,13 +125,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_sfsymbols:
-    dependency: "direct main"
-    description:
-      name: flutter_sfsymbols
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_sfsymbols: ^2.0.0
   provider: ^6.0.3
 
 dev_dependencies:
@@ -22,9 +21,6 @@ flutter:
   uses-material-design: true
 
   fonts:
-    - family: sficonsets
-      fonts:
-        - asset: packages/flutter_sfsymbols/fonts/sficonsets.ttf
     - family: Roboto
       fonts:
         - asset: lib/fonts/Roboto-Thin.ttf


### PR DESCRIPTION
Alternative to #38 

Inside the package we've used sfsymbols for chevrons. Hovever, @dazzlemon has developed a custom painter just for that -- but we didn't migrate to the painter completely.

This PR fixes that.

Also this PR remove the use of sfsymbols in example -- they are unnecessary there.